### PR TITLE
Override sender email OR name

### DIFF
--- a/Dispatcher.php
+++ b/Dispatcher.php
@@ -105,6 +105,9 @@ class Dispatcher
 
         if (strlen($message->getFromEmail()) == 0) {
             $message->setFromEmail($this->defaultSender);
+        }
+
+        if (strlen($message->getFromName()) == 0) {
             $message->setFromName($this->defaultSenderName);
         }
 


### PR DESCRIPTION
Override sender email AND/OR name depending on which is specified in the Message.
Could be useful in some cases, like mine, when you want to change only the name but keep the "default" sender.
