### PR TITLE
Require configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,10 +47,11 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
         ->children()
-            ->arrayNode('default')->isRequired()->cannotBeEmpty()
+            ->arrayNode('default')
+                ->isRequired()
                 ->children()
-                    ->scalarNode('sender')->end()
-                    ->scalarNode('sender_name')->end()
+                    ->scalarNode('sender')->isRequired()->cannotBeEmpty()->end()
+                    ->scalarNode('sender_name')->isRequired()->cannotBeEmpty()->end()
                     ->scalarNode('subaccount')->defaultNull()->end()
                 ->end()
             ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,7 +47,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
         ->children()
-            ->arrayNode('default')
+            ->arrayNode('default')->isRequired()->cannotBeEmpty()
                 ->children()
                     ->scalarNode('sender')->end()
                     ->scalarNode('sender_name')->end()


### PR DESCRIPTION
This means that the error message when using the bundle without configuration will make sense:

Old:

ContextErrorException in HipMandrillExtension.php line 51:
Notice: Undefined index: default

New:

InvalidConfigurationException in ArrayNode.php line 234:
The child node "default" at path "hip_mandrill" must be configured.

This is also more in line with how other bundles do this thing.
