### PR TITLE
Allow empty default sender_name as it is optional in Mandrill Messages

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -51,7 +51,7 @@ class Configuration implements ConfigurationInterface
                 ->isRequired()
                 ->children()
                     ->scalarNode('sender')->isRequired()->cannotBeEmpty()->end()
-                    ->scalarNode('sender_name')->isRequired()->cannotBeEmpty()->end()
+                    ->scalarNode('sender_name')->defaultNull()->end()
                     ->scalarNode('subaccount')->defaultNull()->end()
                 ->end()
             ->end()

--- a/Dispatcher.php
+++ b/Dispatcher.php
@@ -107,7 +107,7 @@ class Dispatcher
             $message->setFromEmail($this->defaultSender);
         }
 
-        if (strlen($message->getFromName()) == 0) {
+        if (strlen($message->getFromName()) == 0 && null !== $this->defaultSenderName) {
             $message->setFromName($this->defaultSenderName);
         }
 
@@ -142,11 +142,11 @@ class Dispatcher
         if ($this->proxy['host'] !== null) {
             curl_setopt($this->service->ch, CURLOPT_PROXY, $this->proxy['host']);
         }
-        
+
         if ($this->proxy['port'] !== null) {
             curl_setopt($this->service->ch, CURLOPT_PROXYPORT, $this->proxy['port']);
         }
-        
+
         if ($this->proxy['user'] !== null && $this->proxy['password'] !== null) {
             curl_setopt($this->service->ch, CURLOPT_PROXYUSERPWD, sprintf(
                 '%s:%s',

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ hip_mandrill:
     disable_delivery: true # useful for dev/test environment. Default value is 'false'
     default:
         sender: info@example.com
-        sender_name: John Doe
+        sender_name: John Doe # Optionally define a sender name (from name)
         subaccount: Project # Optionally define a subaccount to use
     proxy:
         use: true # when you are behing a proxy. Default value is 'false'


### PR DESCRIPTION
The "from_name" in Mandrill Messages API is optional so in my opinion it should be possible to create and send messages without a sender name.
