### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,42 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
+sudo: false
+
 env:
-  - SYMFONY_VERSION=2.3.*
-  - SYMFONY_VERSION=2.4.*
-  - SYMFONY_VERSION=2.5.*
-  - SYMFONY_VERSION=2.6.*
-  - SYMFONY_VERSION=2.7.*@dev
+  global:
+    - SYMFONY_VERSION=""
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.0.*
+  allow_failures:
+    - php: hhvm
+    - env: SYMFONY_VERSION=3.0.*
 
 before_script:
   - wget -nc http://getcomposer.org/composer.phar
   - php composer.phar install
 
-script: phpunit
+before_install:
+  - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
-matrix:
-  allow_failures:
-    - php: hhvm
-    - env: SYMFONY_VERSION=2.7.*@dev
+script: phpunit
 
 notifications:
   email:


### PR DESCRIPTION
Your matrix was very BIG and even if it sounds interesting to test "everything", most of the time there's no need to. Plus, this config runs the build faster thanks to caching composer deps and fast-finish.

I've copied some of the work on [EasyAdminBundle](https://github.com/javiereguiluz/EasyAdminBundle)'s Travis-CI configuration to optimize your builds.

Also, what's important is that I updated Symfony versions for the bundle to be tested with only currently supported versions. `2.4` and `2.5` are not supported, and 2.6 will reach end of support in one month (and migrating from 2.6 to 2.7 only implies a [very marginal BC break](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.7.md#router)).

If you don't agree I might add 2.6 again, but actually 2.4 and 2.5 are useless as they're no more supported.

What do you think? :)
