### PR TITLE
Replacing the abandoned mandrill/mandrill with mailchimp/transactional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "symfony/http-foundation": ">=2.8",
         "symfony/config": ">=2.8",
-        "mandrill/mandrill": "1.*"
+        "mailchimp/transactional": "1.*"
     },
     "require-dev": {
         "symfony/phpunit-bridge": ">=2.8",


### PR DESCRIPTION
Composer is warning about using the abandoned `mandrill/mandrill` package. I have switched this with the recommended replacement.

`Package mandrill/mandrill is abandoned, you should avoid using it. Use mailchimp/transactional instead.`
